### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -1,5 +1,8 @@
 name: Feature CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [feature/*]


### PR DESCRIPTION
Potential fix for [https://github.com/0bvim/webserv/security/code-scanning/1](https://github.com/0bvim/webserv/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow does not appear to require any write permissions, we will set `contents: read` as the minimal permission. This ensures the workflow has only the necessary permissions to read repository contents, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._